### PR TITLE
fix BDH->BHD typo, add 'BIOS' in parens

### DIFF
--- a/rom.go
+++ b/rom.go
@@ -11,8 +11,8 @@ const (
 	XHCIRom   RomType = "XHCI"
 	PSPRom    RomType = "PSP"
 	NewPSPRom RomType = "NEWPSP"
-	BHDRom    RomType = "BHD"
-	NewBHDRom RomType = "NEWBDH"
+	BHDRom    RomType = "BHD (BIOS)"
+	NewBHDRom RomType = "NEWBHD (new BIOS)"
 )
 
 type (


### PR DESCRIPTION
As per PSPTool, BHD is the 'BIOS' directory,
so let's add that here as well. :)